### PR TITLE
feat: add KubeStellar Console to Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Managing 100+ LLM APIs, handling rate limits, implementing fallbacks, and tracki
 - [Guardrails and Security](#guardrails-and-security)
 - [Tutorials and Case Studies](#tutorials-and-case-studies)
 - [Communities](#communities)
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI gateway observability, LLM request monitoring, real-time metrics, and CNCF integrations. CNCF Sandbox project.
 
 ## AI Gateways
 


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) provides observability for AI gateways deployed on Kubernetes: LLM request monitoring, real-time metrics, and multi-cluster visibility. CNCF Sandbox project.\n\n*Happy to adjust description or placement.*