### PR TITLE
docs: add Quotaflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Unified API gateways that route requests across multiple LLM providers.
 - [Vercel AI Gateway](https://sdk.vercel.ai/docs/ai-gateway#readme) - Single endpoint for hundreds of AI models.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/#readme) - Unified interface for AI providers at the edge.
 - [OpenRouter](https://openrouter.ai/#readme) - Unified API for 500+ models from 60+ providers.
+- [Quotaflow](https://quotaflow.ai/#readme) - OpenAI-compatible relay for governed AI API quota pools, routing, and temporary access across teams.
 - [Portkey Hosted](https://portkey.ai/#readme) - Managed AI gateway with 1600+ LLMs and enterprise features.
 - [Braintrust](https://www.braintrust.dev/#readme) - Unified API with encrypted caching and integrated evaluation.
 - [Inworld Router](https://www.inworlds.ai/#readme) - LLM plus TTS pipelining for high-interactivity use cases.


### PR DESCRIPTION
Adds Quotaflow to the Managed Services section as an OpenAI-compatible relay for governed AI API quota pools, routing, and temporary access across teams.