### PR TITLE
Add FerryAPI to managed services

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Unified API gateways that route requests across multiple LLM providers.
 - [Vercel AI Gateway](https://sdk.vercel.ai/docs/ai-gateway#readme) - Single endpoint for hundreds of AI models.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/#readme) - Unified interface for AI providers at the edge.
 - [OpenRouter](https://openrouter.ai/#readme) - Unified API for 500+ models from 60+ providers.
+- [FerryAPI](https://www.ferryapi.io/#readme) - OpenAI-compatible AI API gateway with prepaid balance, usage billing, customer API keys, and provider account pools.
 - [Portkey Hosted](https://portkey.ai/#readme) - Managed AI gateway with 1600+ LLMs and enterprise features.
 - [Braintrust](https://www.braintrust.dev/#readme) - Unified API with encrypted caching and integrated evaluation.
 - [Inworld Router](https://www.inworlds.ai/#readme) - LLM plus TTS pipelining for high-interactivity use cases.


### PR DESCRIPTION
Adds FerryAPI to the Managed Services section near the other hosted AI gateways.

Disclosure: I’m helping with FerryAPI growth / affiliated with the project.