### PR TITLE
Add routerbase to managed AI gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Unified API gateways that route requests across multiple LLM providers.
 - [Vercel AI Gateway](https://sdk.vercel.ai/docs/ai-gateway#readme) - Single endpoint for hundreds of AI models.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/#readme) - Unified interface for AI providers at the edge.
 - [OpenRouter](https://openrouter.ai/#readme) - Unified API for 500+ models from 60+ providers.
+- [routerbase](https://routerbase.com) - OpenAI-compatible AI gateway for 200+ models with smart routing, automatic fallback, unified billing, and usage analytics.
 - [Portkey Hosted](https://portkey.ai/#readme) - Managed AI gateway with 1600+ LLMs and enterprise features.
 - [Braintrust](https://www.braintrust.dev/#readme) - Unified API with encrypted caching and integrated evaluation.
 - [Inworld Router](https://www.inworlds.ai/#readme) - LLM plus TTS pipelining for high-interactivity use cases.


### PR DESCRIPTION
Adds [routerbase](https://routerbase.com) to the managed AI gateways section.\n\nRouterBase is an OpenAI-compatible AI gateway for 200+ models with smart routing, automatic fallback, unified billing, and usage analytics.\n\nDocs: https://docs.routerbase.com/