### PR TITLE
Add llm-swarm-router — local LAN mesh router for oMLX/Ollama/vLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Distribute traffic, implement failovers, and optimize costs.
 - [Routerly Policies](https://www.routerly.ai/#readme) - 9 configurable policies including LLM-native routing.
 - [Lovable: 1.8B tokens per minute load balancing](https://www.adwaitx.com/llm-provider-load-balancing-agent-workflows/#readme) - PID-controlled dynamic load balancing.
 - [RouteLLM](https://github.com/lm-sys/RouteLLM#readme) - Cost-quality routing with trainable lightweight routers.
+- [llm-swarm-router](https://github.com/matthewdcage/llm-swarm-router#readme) - Local LAN mesh router for oMLX, Ollama, LM Studio, vLLM, and llama.cpp backends; OpenAI + Anthropic Messages API on :11400.
 
 ## API Management and Rate Limiting
 • [MuleSoft AI Governance](https://www.mulesoft.com/lp/ai/anypoint-platform-for-ai) - AI-powered API governance and security.


### PR DESCRIPTION
## Summary

Adds [llm-swarm-router](https://github.com/matthewdcage/llm-swarm-router) to **Load Balancing and Routing** — a self-hosted mesh router for **local** LLM backends (not a cloud provider aggregator).

- Discovers oMLX, Ollama, LM Studio, vLLM, and custom OpenAI-compat endpoints on localhost
- mDNS LAN mesh across Mac/Linux/Windows nodes
- OpenAI `/v1` + Anthropic Messages API on `:11400` for Cursor, Claude Code, Codex, Honcho
- MIT · macOS menubar/DMG + Linux/Windows alpha packages

Complements LiteLLM-style cloud routing with a **local LAN mesh** layer.

## Checklist

- [x] Link follows existing list format
- [x] Open-source project with README and releases